### PR TITLE
Fix ppat

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,6 @@
 .idea
 .env
 *-env-*
+
+#File used for tests
+main.go

--- a/hestia/hestia.go
+++ b/hestia/hestia.go
@@ -10,17 +10,14 @@ import (
 	"github.com/grupokindynos/common/tokens/mvt"
 )
 
-// ProductionURL is the current hestia production url
-var ProductionURL = "https://hestia.polispay.com"
-
 // HttpClient a usable client with hardcoded timeout
 var HttpClient = http.Client{
 	Timeout: time.Second * 5,
 }
 
 // GetServiceProperties is a function to return hestia properties for multiple services
-func GetServiceProperties(adminFbToken string) (string, error) {
-	res, err := HttpClient.Get(ProductionURL + "/config")
+func GetServiceProperties(productionURL string, adminFbToken string) (string, error) {
+	res, err := HttpClient.Get(productionURL + "/config")
 	if err != nil {
 	}
 	defer func() {
@@ -45,8 +42,8 @@ func GetServiceProperties(adminFbToken string) (string, error) {
 }
 
 // GetCoinsAvailability is a function to return hestia properties for multiple crypto used on the environment
-func GetCoinsAvailability(adminFbToken string) (string, error) {
-	res, err := HttpClient.Get(ProductionURL + "/coins")
+func GetCoinsAvailability(productionURL string, adminFbToken string) (string, error) {
+	res, err := HttpClient.Get(productionURL + "/coins")
 	if err != nil {
 	}
 	defer func() {
@@ -71,8 +68,8 @@ func GetCoinsAvailability(adminFbToken string) (string, error) {
 }
 
 // VerifyToken ask Hestia if a firebase token is valid
-func VerifyToken(service string, masterPassword string, fbToken string, hestiaAuthUser string, hestiaAuthPass string, servicePrivKey string, hestiaPubKey string) (valid bool, uid string, err error) {
-	req, err := mvt.CreateMVTToken("POST", ProductionURL+"/validate/token", service, masterPassword, fbToken, hestiaAuthUser, hestiaAuthPass, servicePrivKey)
+func VerifyToken(productionURL string, service string, masterPassword string, fbToken string, hestiaAuthUser string, hestiaAuthPass string, servicePrivKey string, hestiaPubKey string) (valid bool, uid string, err error) {
+	req, err := mvt.CreateMVTToken("POST", productionURL+"/validate/token", service, masterPassword, fbToken, hestiaAuthUser, hestiaAuthPass, servicePrivKey)
 	client := http.Client{
 		Timeout: time.Second * 5,
 	}

--- a/tokens/ppat/ppat.go
+++ b/tokens/ppat/ppat.go
@@ -58,7 +58,18 @@ func VerifyPPATToken(service, masterpassword string, tokenHeader string, tokenBo
 		return false, nil, "", err
 	}
 	if tokenBody != "" {
-		payload, err = jwt.DecryptJWE(uid, tokenBody)
+		decryptPayload, err := jwt.DecryptJWE(masterpassword, tokenBody)
+		if err != nil {
+			return false, nil, "", errors.New("unable to decrypt token with master password")
+		}
+
+		var decryptStr string
+		err = json.Unmarshal(decryptPayload, &decryptStr)
+		if err != nil {
+			return false, nil, "", errors.New("unable to unmarshall byte array into string")
+		}
+
+		payload, err = jwt.DecryptJWE(uid, decryptStr)
 		if err != nil {
 			return false, nil, "", errors.New("unable to decrypt token")
 		}

--- a/tokens/ppat/ppat.go
+++ b/tokens/ppat/ppat.go
@@ -52,8 +52,8 @@ func createPPATTokenBody(payload interface{}, uid string) ([]byte, error) {
 }
 
 // VerifyPPATToken is a utility function to verify and decrypt a PPAT token (only must be used for external microservices, Hestia can verify itself)
-func VerifyPPATToken(service, masterpassword string, tokenHeader string, tokenBody string, hestiaAuthUser string, hestiaAuthPassword string, serviceSigningPrivKey string, hestiaPubKey string) (valid bool, payload []byte, uid string, err error) {
-	valid, uid, err = hestia.VerifyToken(service, masterpassword, tokenHeader, hestiaAuthUser, hestiaAuthPassword, serviceSigningPrivKey, hestiaPubKey)
+func VerifyPPATToken(productionURL string, service string, masterpassword string, tokenHeader string, tokenBody string, hestiaAuthUser string, hestiaAuthPassword string, serviceSigningPrivKey string, hestiaPubKey string) (valid bool, payload []byte, uid string, err error) {
+	valid, uid, err = hestia.VerifyToken(productionURL, service, masterpassword, tokenHeader, hestiaAuthUser, hestiaAuthPassword, serviceSigningPrivKey, hestiaPubKey)
 	if !valid {
 		return false, nil, "", err
 	}


### PR DESCRIPTION
# Description

The VerifyPPATToken was not decrypting the payload returned by Hestia using the master password. It tried to decrypt with the uid, but was unable to, sending "unable to verify token" every time.

Also, I changed ProductionURL for Hestia to local methods, so that we can test the common library using a local environment. This will break some methods, as we now need to add ProductionURL to all methods, but I think we need to addd as an environment variable as this are the best practices.


## Type of change

Please delete options that are not relevant.
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)


# Checklist:
- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have made corresponding changes to the documentation.
- [x] My changes generate no new warnings.
- [x] I have added unit tests that prove my fix is effective or that my feature works.
- [x] New and existing unit tests pass locally with my changes.
- [x] Any dependent changes have been merged and published in downstream modules.